### PR TITLE
feat(auth): add credential and deep link support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,8 @@ dependencies {
 
     // Security
     implementation(libs.security.crypto)
+    implementation(libs.credentials)
+    implementation(libs.credentials.play.services.auth)
 
     // Coroutines
     implementation(libs.coroutines.android)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,10 @@
         android:theme="@style/Theme.SakuraAIReviewer"
         tools:targetApi="36">
 
+        <meta-data
+            android:name="asset_statements"
+            android:resource="@string/asset_statements" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -24,6 +28,25 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="sakura-ai-reviewer"
+                    android:host="oauth"
+                    android:path="/callback" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="pr-bot.firefly520.top" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/sakura_ai_reviewer/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/core/network/AuthInterceptor.kt
@@ -21,7 +21,7 @@ class AuthInterceptor @Inject constructor(
         val request = chain.request()
         val path = request.url.encodedPath
 
-        if (NetworkConstants.isPublicPath(path)) {
+        if (NetworkConstants.isPublicPath(path) || request.header("Authorization") != null) {
             return chain.proceed(request)
         }
 

--- a/app/src/main/java/com/sakura_ai_reviewer/core/network/NetworkConstants.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/core/network/NetworkConstants.kt
@@ -1,7 +1,14 @@
 package com.sakura_ai_reviewer.core.network
 
 object NetworkConstants {
-    val PUBLIC_PATHS = listOf("/health", "/auth/github", "/auth/callback", "/setup/")
+    val PUBLIC_PATHS = listOf(
+        "/health",
+        "/auth/github",
+        "/auth/callback",
+        "/auth/passkey/",
+        "/auth/2fa/",
+        "/setup/"
+    )
 
     fun isPublicPath(path: String): Boolean = PUBLIC_PATHS.any { path.contains(it) }
 }

--- a/app/src/main/java/com/sakura_ai_reviewer/core/network/NetworkModule.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/core/network/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.sakura_ai_reviewer.core.network
 
 import com.sakura_ai_reviewer.BuildConfig
 import com.sakura_ai_reviewer.feature.auth.data.AuthApiService
+import com.sakura_ai_reviewer.feature.billing.data.BillingApiService
 import com.sakura_ai_reviewer.feature.config.data.ConfigApiService
 import com.sakura_ai_reviewer.feature.dashboard.data.DashboardApiService
 import com.sakura_ai_reviewer.feature.issue.data.IssueApiService
@@ -13,6 +14,7 @@ import com.sakura_ai_reviewer.feature.scan.data.ScanApiService
 import com.sakura_ai_reviewer.feature.settings.data.SettingsApiService
 import com.sakura_ai_reviewer.feature.setup.data.SetupApiService
 import com.sakura_ai_reviewer.feature.user.data.UserApiService
+import com.sakura_ai_reviewer.feature.userconfig.data.UserConfigApiService
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -129,4 +131,14 @@ object NetworkModule {
     @Singleton
     fun provideSetupApiService(retrofit: Retrofit): SetupApiService =
         retrofit.create(SetupApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideUserConfigApiService(retrofit: Retrofit): UserConfigApiService =
+        retrofit.create(UserConfigApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideBillingApiService(retrofit: Retrofit): BillingApiService =
+        retrofit.create(BillingApiService::class.java)
 }

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/auth/data/AuthApiService.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/auth/data/AuthApiService.kt
@@ -4,10 +4,14 @@ import com.sakura_ai_reviewer.core.network.ApiResponse
 import com.sakura_ai_reviewer.core.network.EmptyData
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Query
+import retrofit2.http.Url
 
 interface AuthApiService {
 
@@ -17,7 +21,30 @@ interface AuthApiService {
     ): ApiResponse<AuthUrlData>
 
     @POST("auth/callback")
-    suspend fun postCallback(@Body request: CallbackRequest): ApiResponse<TokenData>
+    suspend fun postCallback(@Body request: CallbackRequest): ApiResponse<CallbackResponseData>
+
+    @POST("auth/2fa/verify")
+    suspend fun verify2fa(@Body request: Verify2faRequest): ApiResponse<TokenData>
+
+    @POST("auth/2fa/passkey/options")
+    suspend fun getPasskeyOptions(@Body request: PasskeyOptionsRequest): ApiResponse<PasskeyOptionsData>
+
+    @POST("auth/2fa/passkey/verify")
+    suspend fun verifyPasskey(@Body request: PasskeyVerifyRequest): ApiResponse<TokenData>
+
+    @POST
+    suspend fun discoverPasskey(@Url url: String): ApiResponse<PasskeyOptionsData>
+
+    @POST
+    suspend fun verifyDiscoverPasskey(
+        @Url url: String,
+        @Body request: DirectPasskeyVerifyRequest
+    ): Response<ApiResponse<WebUiPasskeyVerifyData>>
+
+    @GET("auth/me")
+    suspend fun getMeWithToken(
+        @Header("Authorization") authorization: String
+    ): ApiResponse<UserData>
 
     @POST("auth/logout")
     suspend fun logout(): ApiResponse<EmptyData>
@@ -36,6 +63,22 @@ data class AuthUrlData(
 data class CallbackRequest(
     @Json(name = "code") val code: String,
     @Json(name = "state") val state: String
+)
+
+/**
+ * OAuth callback 响应可能是直接签发 token 或需要 MFA 验证。
+ * - message="ok" 时 data 为 TokenData
+ * - message="mfa_required" 时 data 为 MfaRequiredData
+ */
+@JsonClass(generateAdapter = true)
+data class CallbackResponseData(
+    @Json(name = "access_token") val accessToken: String? = null,
+    @Json(name = "token_type") val tokenType: String? = null,
+    @Json(name = "expires_in") val expiresIn: Long? = null,
+    @Json(name = "user") val user: TokenUserData? = null,
+    @Json(name = "mfa_required") val mfaRequired: Boolean? = null,
+    @Json(name = "mfa_token") val mfaToken: String? = null,
+    @Json(name = "methods") val methods: List<String>? = null
 )
 
 @JsonClass(generateAdapter = true)
@@ -63,3 +106,52 @@ data class UserData(
     @Json(name = "github_id") val githubId: Int? = null,
     @Json(name = "avatar_url") val avatarUrl: String? = null
 )
+
+@JsonClass(generateAdapter = true)
+data class Verify2faRequest(
+    @Json(name = "mfa_token") val mfaToken: String,
+    @Json(name = "code") val code: String
+)
+
+@JsonClass(generateAdapter = true)
+data class PasskeyOptionsRequest(
+    @Json(name = "mfa_token") val mfaToken: String
+)
+
+@JsonClass(generateAdapter = true)
+data class PasskeyOptionsData(
+    @Json(name = "challenge_id") val challengeId: String,
+    @Json(name = "public_key") val publicKey: PasskeyPublicKeyData,
+    @Json(name = "rp_id") val rpId: String,
+    @Json(name = "origin") val origin: String
+)
+
+@JsonClass(generateAdapter = true)
+data class PasskeyPublicKeyData(
+    @Json(name = "challenge") val challenge: String,
+    @Json(name = "rpId") val rpId: String,
+    @Json(name = "allowCredentials") val allowCredentials: List<Map<String, Any?>>? = null,
+    @Json(name = "timeout") val timeout: Int? = null,
+    @Json(name = "userVerification") val userVerification: String? = null
+) {
+    fun toRequestJson(moshi: Moshi): String = moshi.adapter(PasskeyPublicKeyData::class.java).toJson(this)
+}
+
+@JsonClass(generateAdapter = true)
+data class PasskeyVerifyRequest(
+    @Json(name = "mfa_token") val mfaToken: String,
+    @Json(name = "challenge_id") val challengeId: String,
+    @Json(name = "credential") val credential: Map<String, Any>
+)
+
+@JsonClass(generateAdapter = true)
+data class DirectPasskeyVerifyRequest(
+    @Json(name = "challenge_id") val challengeId: String,
+    @Json(name = "credential") val credential: Map<String, Any>
+)
+
+@JsonClass(generateAdapter = true)
+data class WebUiPasskeyVerifyData(
+    @Json(name = "redirect") val redirect: String? = null
+)
+

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/auth/ui/AuthViewModel.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/auth/ui/AuthViewModel.kt
@@ -1,23 +1,34 @@
 package com.sakura_ai_reviewer.feature.auth.ui
 
+import android.util.Base64
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sakura_ai_reviewer.BuildConfig
 import com.sakura_ai_reviewer.core.auth.AuthState
 import com.sakura_ai_reviewer.core.auth.SessionManager
 import com.sakura_ai_reviewer.core.network.toUserMessage
 import com.sakura_ai_reviewer.feature.auth.data.AuthApiService
 import com.sakura_ai_reviewer.feature.auth.data.CallbackRequest
+import com.sakura_ai_reviewer.feature.auth.data.DirectPasskeyVerifyRequest
+import com.sakura_ai_reviewer.feature.auth.data.PasskeyOptionsRequest
+import com.sakura_ai_reviewer.feature.auth.data.PasskeyVerifyRequest
+import com.sakura_ai_reviewer.feature.auth.data.Verify2faRequest
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 import javax.inject.Inject
+
+private const val MOBILE_OAUTH_REDIRECT_URI = "sakura-ai-reviewer://oauth/callback"
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val sessionManager: SessionManager,
-    private val authApiService: AuthApiService
+    private val authApiService: AuthApiService,
+    val moshi: Moshi
 ) : ViewModel() {
 
     val authState: StateFlow<AuthState> = sessionManager.authState
@@ -25,11 +36,34 @@ class AuthViewModel @Inject constructor(
     private val _loginState = MutableStateFlow<LoginState>(LoginState.Idle)
     val loginState: StateFlow<LoginState> = _loginState.asStateFlow()
 
-    fun initiateGitHubLogin() {
+
+    fun initiatePasskeyLogin() {
         viewModelScope.launch {
             _loginState.value = LoginState.Loading
             try {
-                val response = authApiService.getMobileAuthUrl()
+                val response = authApiService.discoverPasskey(webUiUrl("auth/passkey/discover"))
+                if (response.success && response.data != null) {
+                    _loginState.value = LoginState.PasskeyOptionsReady(
+                        mfaToken = null,
+                        challengeId = response.data.challengeId,
+                        publicKey = response.data.publicKey,
+                        rpId = response.data.rpId,
+                        origin = response.data.origin
+                    )
+                } else {
+                    _loginState.value = LoginState.Error(response.error ?: "Failed to get passkey options")
+                }
+            } catch (e: Exception) {
+                _loginState.value = LoginState.Error(e.toUserMessage())
+            }
+        }
+    }
+
+    fun initiateGitHubLogin(redirectUri: String = MOBILE_OAUTH_REDIRECT_URI) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.Loading
+            try {
+                val response = authApiService.getMobileAuthUrl(redirectUri)
                 if (response.success && response.data != null) {
                     _loginState.value = LoginState.GotAuthUrl(
                         authorizationUrl = response.data.authorizationUrl,
@@ -52,6 +86,44 @@ class AuthViewModel @Inject constructor(
             try {
                 val response = authApiService.postCallback(CallbackRequest(code, state))
                 if (response.success && response.data != null) {
+                    val data = response.data
+                    if (data.mfaRequired == true && data.mfaToken != null) {
+                        _loginState.value = LoginState.MfaRequired(
+                            mfaToken = data.mfaToken,
+                            methods = data.methods ?: emptyList(),
+                            username = data.user?.sub ?: "",
+                            avatarUrl = data.user?.avatarUrl
+                        )
+                    } else if (data.accessToken != null && data.user != null) {
+                        sessionManager.onLoginSuccess(
+                            accessToken = data.accessToken,
+                            expiresIn = data.expiresIn ?: 86400L,
+                            role = data.user.role,
+                            userId = data.user.userId,
+                            username = data.user.sub,
+                            avatarUrl = data.user.avatarUrl
+                        )
+                        _loginState.value = LoginState.Success
+                    } else {
+                        _loginState.value = LoginState.Error("Unexpected response")
+                    }
+                } else {
+                    _loginState.value = LoginState.Error(
+                        response.error ?: "Authentication failed"
+                    )
+                }
+            } catch (e: Exception) {
+                _loginState.value = LoginState.Error(e.toUserMessage())
+            }
+        }
+    }
+
+    fun verifyTotpCode(mfaToken: String, code: String) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.Loading
+            try {
+                val response = authApiService.verify2fa(Verify2faRequest(mfaToken, code))
+                if (response.success && response.data != null) {
                     val tokenData = response.data
                     sessionManager.onLoginSuccess(
                         accessToken = tokenData.accessToken,
@@ -64,7 +136,7 @@ class AuthViewModel @Inject constructor(
                     _loginState.value = LoginState.Success
                 } else {
                     _loginState.value = LoginState.Error(
-                        response.error ?: "Authentication failed"
+                        response.error ?: "Verification failed"
                     )
                 }
             } catch (e: Exception) {
@@ -73,12 +145,114 @@ class AuthViewModel @Inject constructor(
         }
     }
 
+    fun startPasskeyAuth(mfaToken: String) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.Loading
+            try {
+                val response = authApiService.getPasskeyOptions(PasskeyOptionsRequest(mfaToken))
+                if (response.success && response.data != null) {
+                    _loginState.value = LoginState.PasskeyOptionsReady(
+                        mfaToken = mfaToken,
+                        challengeId = response.data.challengeId,
+                        publicKey = response.data.publicKey,
+                        rpId = response.data.rpId,
+                        origin = response.data.origin
+                    )
+                } else {
+                    _loginState.value = LoginState.Error(
+                        response.error ?: "Failed to get passkey options"
+                    )
+                }
+            } catch (e: Exception) {
+                _loginState.value = LoginState.Error(e.toUserMessage())
+            }
+        }
+    }
+
+    fun verifyPasskey(mfaToken: String?, challengeId: String, credential: Map<String, Any>) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.Loading
+            try {
+                if (mfaToken != null) {
+                    val response = authApiService.verifyPasskey(
+                        PasskeyVerifyRequest(mfaToken, challengeId, credential)
+                    )
+                    if (response.success && response.data != null) {
+                        val tokenData = response.data
+                        sessionManager.onLoginSuccess(
+                            accessToken = tokenData.accessToken,
+                            expiresIn = tokenData.expiresIn,
+                            role = tokenData.user.role,
+                            userId = tokenData.user.userId,
+                            username = tokenData.user.sub,
+                            avatarUrl = tokenData.user.avatarUrl
+                        )
+                        _loginState.value = LoginState.Success
+                    } else {
+                        _loginState.value = LoginState.Error(response.error ?: "Passkey verification failed")
+                    }
+                } else {
+                    completeDirectPasskeyLogin(challengeId, credential)
+                }
+            } catch (e: Exception) {
+                _loginState.value = LoginState.Error(e.toUserMessage())
+            }
+        }
+    }
+
+    private suspend fun completeDirectPasskeyLogin(challengeId: String, credential: Map<String, Any>) {
+        val response = authApiService.verifyDiscoverPasskey(
+            webUiUrl("auth/passkey/verify-discover"),
+            DirectPasskeyVerifyRequest(challengeId, credential)
+        )
+        if (!response.isSuccessful) {
+            _loginState.value = LoginState.Error("Passkey verification failed")
+            return
+        }
+        val token = response.headers().values("Set-Cookie")
+            .asSequence()
+            .flatMap { it.split(';').asSequence() }
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("webui_token=") }
+            ?.substringAfter('=')
+        if (token.isNullOrBlank()) {
+            _loginState.value = LoginState.Error("Passkey login did not return a token")
+            return
+        }
+        val claims = tokenPayload(token)
+        val expiresIn = (claims.optLong("exp", 0L) - System.currentTimeMillis() / 1000)
+            .coerceAtLeast(60L)
+        val tokenUser = runCatching { authApiService.getMeWithToken("Bearer $token") }
+            .getOrNull()
+            ?.takeIf { it.success }
+            ?.data
+        sessionManager.onLoginSuccess(
+            accessToken = token,
+            expiresIn = expiresIn,
+            role = tokenUser?.role ?: claims.optString("role", "user"),
+            userId = tokenUser?.userId ?: claims.optInt("user_id", -1),
+            username = tokenUser?.sub ?: claims.optString("sub", ""),
+            avatarUrl = tokenUser?.avatarUrl ?: claims.optString("avatar_url").takeIf { it.isNotBlank() }
+        )
+        _loginState.value = LoginState.Success
+    }
+
+    private fun webUiUrl(path: String): String {
+        val base = BuildConfig.BASE_URL.removeSuffix("/").removeSuffix("/api/v1")
+        return "$base/$path"
+    }
+
+    private fun tokenPayload(token: String): JSONObject {
+        val payload = token.split('.').getOrNull(1).orEmpty()
+        val json = String(Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
+        return JSONObject(json)
+    }
+
     fun logout() {
         viewModelScope.launch {
             try {
                 authApiService.logout()
             } catch (_: Exception) {
-                // Ignore network errors on logout
             }
             sessionManager.logout()
         }
@@ -94,5 +268,18 @@ sealed class LoginState {
     data object Loading : LoginState()
     data class GotAuthUrl(val authorizationUrl: String, val state: String) : LoginState()
     data object Success : LoginState()
+    data class MfaRequired(
+        val mfaToken: String,
+        val methods: List<String>,
+        val username: String,
+        val avatarUrl: String?
+    ) : LoginState()
+    data class PasskeyOptionsReady(
+        val mfaToken: String?,
+        val challengeId: String,
+        val publicKey: com.sakura_ai_reviewer.feature.auth.data.PasskeyPublicKeyData,
+        val rpId: String,
+        val origin: String
+    ) : LoginState()
     data class Error(val message: String) : LoginState()
 }

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/auth/ui/LoginScreen.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/auth/ui/LoginScreen.kt
@@ -2,28 +2,36 @@ package com.sakura_ai_reviewer.feature.auth.ui
 
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
+import android.util.Log
 import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import org.json.JSONArray
+import org.json.JSONObject
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Password
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,11 +42,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.PublicKeyCredential
+import androidx.credentials.exceptions.GetCredentialException
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sakura_ai_reviewer.core.ui.theme.Primary
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun LoginScreen(
@@ -66,12 +86,276 @@ fun LoginScreen(
                 }
             )
         }
+        is LoginState.MfaRequired -> {
+            MfaVerifyScreen(
+                loginState = loginState as LoginState.MfaRequired,
+                onVerifyTotp = { code -> viewModel.verifyTotpCode(
+                    (loginState as LoginState.MfaRequired).mfaToken, code
+                )},
+                onStartPasskey = { viewModel.startPasskeyAuth(
+                    (loginState as LoginState.MfaRequired).mfaToken
+                )},
+                onBack = { viewModel.resetLoginState() }
+            )
+        }
+        is LoginState.PasskeyOptionsReady -> {
+            PasskeyVerifyScreen(
+                loginState = loginState as LoginState.PasskeyOptionsReady,
+                moshi = viewModel.moshi,
+                onVerify = { credential -> viewModel.verifyPasskey(
+                    (loginState as LoginState.PasskeyOptionsReady).mfaToken,
+                    (loginState as LoginState.PasskeyOptionsReady).challengeId,
+                    credential
+                )},
+                onBack = { viewModel.resetLoginState() }
+            )
+        }
         else -> {
             LoginContent(
                 loginState = loginState,
                 onLoginClick = { viewModel.initiateGitHubLogin() },
+                onPasskeyLoginClick = { viewModel.initiatePasskeyLogin() },
                 onRetryClick = { viewModel.resetLoginState() }
             )
+        }
+    }
+}
+
+@Composable
+private fun MfaVerifyScreen(
+    loginState: LoginState.MfaRequired,
+    onVerifyTotp: (String) -> Unit,
+    onStartPasskey: () -> Unit,
+    onBack: () -> Unit
+) {
+    var totpCode by remember { mutableStateOf("") }
+    var isLoading by remember { mutableStateOf(false) }
+    val hasTotp = loginState.methods.contains("totp")
+    val hasPasskey = loginState.methods.contains("passkey")
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Password,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = Primary
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Two-Step Verification",
+            style = MaterialTheme.typography.headlineMedium,
+            color = Primary
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Your account requires additional verification",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator(color = Primary, modifier = Modifier.size(48.dp))
+        } else {
+            if (hasTotp) {
+                OutlinedTextField(
+                    value = totpCode,
+                    onValueChange = { if (it.length <= 6) totpCode = it },
+                    label = { Text("Verification Code") },
+                    placeholder = { Text("6-digit code") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .widthIn(max = 400.dp),
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = {
+                        isLoading = true
+                        onVerifyTotp(totpCode)
+                    },
+                    enabled = totpCode.length == 6,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .widthIn(max = 400.dp)
+                        .height(56.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    shape = MaterialTheme.shapes.medium
+                ) {
+                    Text("Verify", style = MaterialTheme.typography.titleMedium)
+                }
+            }
+
+            if (hasTotp && hasPasskey) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text("or", style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            if (hasPasskey) {
+                Button(
+                    onClick = {
+                        isLoading = true
+                        onStartPasskey()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .widthIn(max = 400.dp)
+                        .height(56.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Primary
+                    ),
+                    shape = MaterialTheme.shapes.medium
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Key,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text("Use Passkey", style = MaterialTheme.typography.titleMedium)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = 400.dp)
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasskeyVerifyScreen(
+    loginState: LoginState.PasskeyOptionsReady,
+    moshi: Moshi,
+    onVerify: (Map<String, Any>) -> Unit,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    var isLoading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(loginState.challengeId) {
+        isLoading = true
+        errorMessage = null
+        try {
+            val credentialManager = CredentialManager.create(context)
+            val requestJson = loginState.publicKey.toRequestJson(moshi)
+            val credentialResponse = withContext(Dispatchers.IO) {
+                credentialManager.getCredential(
+                    context = context,
+                    request = GetCredentialRequest(
+                        listOf(GetPublicKeyCredentialOption(requestJson))
+                    )
+                )
+            }
+            val credential = credentialResponse.credential
+            if (credential is PublicKeyCredential) {
+                onVerify(jsonObjectToMap(JSONObject(credential.authenticationResponseJson)))
+            } else {
+                errorMessage = "Unsupported credential type"
+            }
+        } catch (e: GetCredentialException) {
+            Log.e("PasskeyVerifyScreen", "Credential Manager failed: ${e::class.java.name}, type=${e.type}, message=${e.message}", e)
+            errorMessage = e.message ?: "Passkey authentication failed"
+        } catch (e: Exception) {
+            Log.e("PasskeyVerifyScreen", "Passkey authentication failed: ${e::class.java.name}, message=${e.message}", e)
+            errorMessage = e.message ?: "Passkey authentication failed"
+        } finally {
+            isLoading = false
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Key,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = Primary
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Passkey Authentication",
+            style = MaterialTheme.typography.headlineMedium,
+            color = Primary
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Complete authentication using your passkey",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (isLoading) {
+            CircularProgressIndicator(color = Primary, modifier = Modifier.size(48.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Waiting for passkey verification...",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        errorMessage?.let { message ->
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .widthIn(max = 400.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Back")
+            }
         }
     }
 }
@@ -80,6 +364,7 @@ fun LoginScreen(
 private fun LoginContent(
     loginState: LoginState,
     onLoginClick: () -> Unit,
+    onPasskeyLoginClick: () -> Unit,
     onRetryClick: () -> Unit
 ) {
     Column(
@@ -121,6 +406,29 @@ private fun LoginContent(
                 modifier = Modifier.size(48.dp)
             )
         } else {
+            Button(
+                onClick = onPasskeyLoginClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = 400.dp)
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Primary),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Key,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "Sign in with Passkey",
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             Button(
                 onClick = onLoginClick,
                 modifier = Modifier
@@ -186,13 +494,11 @@ private fun OAuthWebView(
                         ): Boolean {
                             val url = request?.url?.toString() ?: return false
 
-                            // Intercept the callback URL from the server
-                            if (url.contains("/auth/callback")) {
+                            if (url.contains("/auth/callback") || url.startsWith("sakura-ai-reviewer://oauth/callback")) {
                                 val uri = request.url
                                 val error = uri.getQueryParameter("error")
 
                                 if (error != null) {
-                                    // User denied authorization or other OAuth error
                                     onError()
                                     return true
                                 }
@@ -232,4 +538,25 @@ private fun OAuthWebView(
             )
         }
     }
+}
+
+private fun jsonObjectToMap(jsonObject: JSONObject): Map<String, Any> = buildMap {
+    val keys = jsonObject.keys()
+    while (keys.hasNext()) {
+        val key = keys.next()
+        put(key, jsonValueToKotlin(jsonObject.get(key)))
+    }
+}
+
+private fun jsonArrayToList(jsonArray: JSONArray): List<Any> = buildList {
+    for (index in 0 until jsonArray.length()) {
+        add(jsonValueToKotlin(jsonArray.get(index)))
+    }
+}
+
+private fun jsonValueToKotlin(value: Any): Any = when (value) {
+    is JSONObject -> jsonObjectToMap(value)
+    is JSONArray -> jsonArrayToList(value)
+    JSONObject.NULL -> ""
+    else -> value
 }

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/billing/data/BillingApiService.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/billing/data/BillingApiService.kt
@@ -1,0 +1,212 @@
+package com.sakura_ai_reviewer.feature.billing.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface BillingApiService {
+
+    @GET("billing/plans")
+    suspend fun getPlans(): List<PlanData>
+
+    @POST("billing/redeem")
+    suspend fun redeemCode(@Body body: RedeemCodeRequest): RedeemCodeResponse
+
+    @GET("billing/orders")
+    suspend fun getOrders(
+        @Query("limit") limit: Int = 20,
+        @Query("offset") offset: Int = 0
+    ): OrdersResponse
+
+    @POST("billing/admin/plans")
+    suspend fun createPlan(@Body body: CreatePlanRequest): CreatePlanResponse
+
+    @PUT("billing/admin/plans/{planId}")
+    suspend fun updatePlan(
+        @Path("planId") planId: Int,
+        @Body body: UpdatePlanRequest
+    ): UpdatePlanResponse
+
+    @DELETE("billing/admin/plans/{planId}")
+    suspend fun deletePlan(
+        @Path("planId") planId: Int,
+        @Query("hard") hard: Boolean = false
+    ): DeletePlanResponse
+
+    @POST("billing/admin/codes/generate")
+    suspend fun generateCodes(@Body body: GenerateCodesRequest): GenerateCodesResponse
+
+    @PUT("billing/admin/codes/{codeId}")
+    suspend fun updateCode(
+        @Path("codeId") codeId: Int,
+        @Body body: UpdateCodeRequest
+    ): UpdateCodeResponse
+
+    @DELETE("billing/admin/codes/{codeId}")
+    suspend fun deleteCode(@Path("codeId") codeId: Int): DeleteCodeResponse
+
+    @POST("billing/admin/grant")
+    suspend fun grantPlan(@Body body: GrantPlanRequest): GrantPlanResponse
+}
+
+@JsonClass(generateAdapter = true)
+data class PlanData(
+    @Json(name = "id") val id: Int,
+    @Json(name = "name") val name: String,
+    @Json(name = "plan_type") val planType: String,
+    @Json(name = "price_cents") val priceCents: Int? = null,
+    @Json(name = "currency") val currency: String? = null,
+    @Json(name = "duration_days") val durationDays: Int? = null,
+    @Json(name = "pr_quota_bonus") val prQuotaBonus: Int? = null,
+    @Json(name = "pr_daily_add") val prDailyAdd: Int? = null,
+    @Json(name = "pr_weekly_add") val prWeeklyAdd: Int? = null,
+    @Json(name = "pr_monthly_add") val prMonthlyAdd: Int? = null,
+    @Json(name = "issue_quota_bonus") val issueQuotaBonus: Int? = null,
+    @Json(name = "issue_daily_add") val issueDailyAdd: Int? = null,
+    @Json(name = "issue_weekly_add") val issueWeeklyAdd: Int? = null,
+    @Json(name = "issue_monthly_add") val issueMonthlyAdd: Int? = null,
+    @Json(name = "description") val description: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class RedeemCodeRequest(
+    @Json(name = "code") val code: String
+)
+
+@JsonClass(generateAdapter = true)
+data class RedeemCodeResponse(
+    @Json(name = "success") val success: Boolean,
+    @Json(name = "order_no") val orderNo: String? = null,
+    @Json(name = "plan_name") val planName: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class OrdersResponse(
+    @Json(name = "total") val total: Int,
+    @Json(name = "orders") val orders: List<OrderData>
+)
+
+@JsonClass(generateAdapter = true)
+data class OrderData(
+    @Json(name = "id") val id: Int,
+    @Json(name = "order_no") val orderNo: String,
+    @Json(name = "plan_name") val planName: String,
+    @Json(name = "amount_cents") val amountCents: Int,
+    @Json(name = "currency") val currency: String,
+    @Json(name = "status") val status: String,
+    @Json(name = "payment_provider") val paymentProvider: String,
+    @Json(name = "created_at") val createdAt: String,
+    @Json(name = "fulfilled_at") val fulfilledAt: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class CreatePlanRequest(
+    @Json(name = "name") val name: String,
+    @Json(name = "plan_type") val planType: String,
+    @Json(name = "price_cents") val priceCents: Int? = null,
+    @Json(name = "currency") val currency: String? = null,
+    @Json(name = "duration_days") val durationDays: Int? = null,
+    @Json(name = "pr_quota_bonus") val prQuotaBonus: Int? = null,
+    @Json(name = "issue_quota_bonus") val issueQuotaBonus: Int? = null,
+    @Json(name = "pr_daily_add") val prDailyAdd: Int? = null,
+    @Json(name = "pr_weekly_add") val prWeeklyAdd: Int? = null,
+    @Json(name = "pr_monthly_add") val prMonthlyAdd: Int? = null,
+    @Json(name = "issue_daily_add") val issueDailyAdd: Int? = null,
+    @Json(name = "issue_weekly_add") val issueWeeklyAdd: Int? = null,
+    @Json(name = "issue_monthly_add") val issueMonthlyAdd: Int? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "sort_order") val sortOrder: Int? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class CreatePlanResponse(
+    @Json(name = "id") val id: Int,
+    @Json(name = "name") val name: String
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdatePlanRequest(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "plan_type") val planType: String? = null,
+    @Json(name = "price_cents") val priceCents: Int? = null,
+    @Json(name = "currency") val currency: String? = null,
+    @Json(name = "duration_days") val durationDays: Int? = null,
+    @Json(name = "pr_quota_bonus") val prQuotaBonus: Int? = null,
+    @Json(name = "issue_quota_bonus") val issueQuotaBonus: Int? = null,
+    @Json(name = "pr_daily_add") val prDailyAdd: Int? = null,
+    @Json(name = "pr_weekly_add") val prWeeklyAdd: Int? = null,
+    @Json(name = "pr_monthly_add") val prMonthlyAdd: Int? = null,
+    @Json(name = "issue_daily_add") val issueDailyAdd: Int? = null,
+    @Json(name = "issue_weekly_add") val issueWeeklyAdd: Int? = null,
+    @Json(name = "issue_monthly_add") val issueMonthlyAdd: Int? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "sort_order") val sortOrder: Int? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdatePlanResponse(
+    @Json(name = "id") val id: Int,
+    @Json(name = "name") val name: String
+)
+
+@JsonClass(generateAdapter = true)
+data class DeletePlanResponse(
+    @Json(name = "success") val success: Boolean,
+    @Json(name = "id") val id: Int,
+    @Json(name = "name") val name: String,
+    @Json(name = "hard_delete") val hardDelete: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class GenerateCodesRequest(
+    @Json(name = "plan_id") val planId: Int,
+    @Json(name = "count") val count: Int,
+    @Json(name = "batch_name") val batchName: String? = null,
+    @Json(name = "max_uses") val maxUses: Int? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class GenerateCodesResponse(
+    @Json(name = "count") val count: Int,
+    @Json(name = "codes") val codes: List<String>
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdateCodeRequest(
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "expires_at") val expiresAt: String? = null,
+    @Json(name = "max_uses") val maxUses: Int? = null,
+    @Json(name = "plan_id") val planId: Int? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdateCodeResponse(
+    @Json(name = "success") val success: Boolean? = null,
+    @Json(name = "id") val id: Int? = null,
+    @Json(name = "code") val code: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class DeleteCodeResponse(
+    @Json(name = "success") val success: Boolean,
+    @Json(name = "id") val id: Int,
+    @Json(name = "code") val code: String
+)
+
+@JsonClass(generateAdapter = true)
+data class GrantPlanRequest(
+    @Json(name = "user_id") val userId: Int,
+    @Json(name = "plan_id") val planId: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class GrantPlanResponse(
+    @Json(name = "success") val success: Boolean,
+    @Json(name = "order_no") val orderNo: String? = null
+)

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/config/data/ConfigApiService.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/config/data/ConfigApiService.kt
@@ -7,10 +7,20 @@ import com.squareup.moshi.JsonClass
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface ConfigApiService {
+
+    @GET("config/ai-providers")
+    suspend fun getAiProviders(): ApiResponse<AiProvidersData>
+
+    @POST("config/ai-providers/{provider}/models")
+    suspend fun getProviderModels(
+        @Path("provider") provider: String,
+        @Body body: ProviderModelsRequest? = null
+    ): ApiResponse<ProviderModelsData>
 
     @GET("config/general")
     suspend fun getGeneralConfig(): ApiResponse<GeneralConfigData>
@@ -36,7 +46,45 @@ interface ConfigApiService {
     suspend fun updateLabels(
         @Body body: UpdateLabelsRequest
     ): ApiResponse<EmptyData>
+
+    @PATCH("config/labels/recommendation")
+    suspend fun updateLabelRecommendation(
+        @Body body: UpdateLabelRecommendationRequest
+    ): ApiResponse<EmptyData>
 }
+
+@JsonClass(generateAdapter = true)
+data class AiProvidersData(
+    @Json(name = "providers") val providers: List<AiProviderItem>
+)
+
+@JsonClass(generateAdapter = true)
+data class AiProviderItem(
+    @Json(name = "id") val id: String,
+    @Json(name = "label") val label: String,
+    @Json(name = "base_url") val baseUrl: String? = null,
+    @Json(name = "default_model") val defaultModel: String? = null,
+    @Json(name = "models_endpoint") val modelsEndpoint: String? = null,
+    @Json(name = "model_detail_endpoint") val modelDetailEndpoint: String? = null,
+    @Json(name = "supports_model_list") val supportsModelList: Boolean? = null,
+    @Json(name = "supports_context_window") val supportsContextWindow: Boolean? = null,
+    @Json(name = "notes") val notes: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class ProviderModelsRequest(
+    @Json(name = "api_key") val apiKey: String? = null,
+    @Json(name = "api_base") val apiBase: String? = null,
+    @Json(name = "model") val model: String? = null
+)
+
+@JsonClass(generateAdapter = true)
+data class ProviderModelsData(
+    @Json(name = "success") val success: Boolean,
+    @Json(name = "models") val models: List<String>? = null,
+    @Json(name = "context_window_k") val contextWindowK: Int? = null,
+    @Json(name = "message") val message: String? = null
+)
 
 @JsonClass(generateAdapter = true)
 data class GeneralConfigData(
@@ -67,4 +115,9 @@ data class LabelsData(
 @JsonClass(generateAdapter = true)
 data class UpdateLabelsRequest(
     @Json(name = "labels") val labels: List<Any>
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdateLabelRecommendationRequest(
+    @Json(name = "recommendation") val recommendation: Map<String, Any>
 )

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/review/data/ReviewApiService.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/review/data/ReviewApiService.kt
@@ -3,9 +3,11 @@ package com.sakura_ai_reviewer.feature.review.data
 import com.sakura_ai_reviewer.core.network.ApiResponse
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import okhttp3.ResponseBody
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Streaming
 
 interface ReviewApiService {
 
@@ -28,11 +30,25 @@ interface ReviewApiService {
         @Path("reviewId") reviewId: Int
     ): ApiResponse<List<ReviewFileData>>
 
+    @Streaming
+    @GET("reviews/export")
+    suspend fun exportReviews(
+        @Query("search") search: String = "",
+        @Query("status") status: String = "",
+        @Query("decision") decision: String = ""
+    ): ResponseBody
+
     @GET("reviews/{reviewId}/comments")
     suspend fun getReviewComments(
         @Path("reviewId") reviewId: Int,
         @Query("file_path") filePath: String = ""
     ): ApiResponse<List<ReviewCommentData>>
+
+    @GET("reviews/{reviewId}/files/{filePath}")
+    suspend fun getFileComments(
+        @Path("reviewId") reviewId: Int,
+        @Path("filePath") filePath: String
+    ): ApiResponse<FileCommentsData>
 }
 
 @JsonClass(generateAdapter = true)
@@ -123,4 +139,21 @@ data class SeverityCountsData(
     @Json(name = "major") val major: Int,
     @Json(name = "minor") val minor: Int,
     @Json(name = "suggestion") val suggestion: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class FileCommentsData(
+    @Json(name = "file_path") val filePath: String,
+    @Json(name = "comment_count") val commentCount: Int,
+    @Json(name = "comments") val comments: List<FileCommentItem>
+)
+
+@JsonClass(generateAdapter = true)
+data class FileCommentItem(
+    @Json(name = "id") val id: Int,
+    @Json(name = "line_number") val lineNumber: Int? = null,
+    @Json(name = "comment_type") val commentType: String? = null,
+    @Json(name = "severity") val severity: String? = null,
+    @Json(name = "content") val content: String? = null,
+    @Json(name = "created_at") val createdAt: String? = null
 )

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/setup/data/SetupApiService.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/setup/data/SetupApiService.kt
@@ -1,11 +1,15 @@
 package com.sakura_ai_reviewer.feature.setup.data
 
 import com.sakura_ai_reviewer.core.network.ApiResponse
+import com.sakura_ai_reviewer.feature.config.data.AiProvidersData
+import com.sakura_ai_reviewer.feature.config.data.ProviderModelsData
+import com.sakura_ai_reviewer.feature.config.data.ProviderModelsRequest
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface SetupApiService {
 
@@ -16,6 +20,15 @@ interface SetupApiService {
     suspend fun testConnection(
         @Body request: TestConnectionRequest
     ): ApiResponse<TestConnectionResultData>
+
+    @GET("setup/ai-providers")
+    suspend fun getAiProviders(): ApiResponse<AiProvidersData>
+
+    @POST("setup/ai-providers/{provider}/models")
+    suspend fun getProviderModels(
+        @Path("provider") provider: String,
+        @Body body: ProviderModelsRequest? = null
+    ): ApiResponse<ProviderModelsData>
 
     @POST("setup/save-step")
     suspend fun saveStep(
@@ -53,8 +66,10 @@ data class TestConnectionRequest(
     @Json(name = "redis_url") val redisUrl: String? = null,
     @Json(name = "app_id") val appId: String? = null,
     @Json(name = "private_key") val privateKey: String? = null,
+    @Json(name = "provider") val provider: String? = null,
     @Json(name = "api_key") val apiKey: String? = null,
     @Json(name = "api_base") val apiBase: String? = null,
+    @Json(name = "model") val model: String? = null,
     @Json(name = "bot_token") val botToken: String? = null
 )
 
@@ -81,9 +96,11 @@ data class CompleteSetupRequest(
     @Json(name = "GITHUB_APP_ID") val githubAppId: String? = null,
     @Json(name = "GITHUB_PRIVATE_KEY") val githubPrivateKey: String? = null,
     @Json(name = "GITHUB_WEBHOOK_SECRET") val githubWebhookSecret: String? = null,
+    @Json(name = "AI_PROVIDER") val aiProvider: String? = null,
     @Json(name = "OPENAI_API_KEY") val openaiApiKey: String? = null,
     @Json(name = "OPENAI_API_BASE") val openaiApiBase: String? = null,
     @Json(name = "OPENAI_MODEL") val openaiModel: String? = null,
+    @Json(name = "SUMMARY_PROVIDER") val summaryProvider: String? = null,
     @Json(name = "TELEGRAM_BOT_TOKEN") val telegramBotToken: String? = null,
     @Json(name = "APP_DOMAIN") val appDomain: String? = null,
     @Json(name = "APP_PORT") val appPort: String? = null,

--- a/app/src/main/java/com/sakura_ai_reviewer/feature/userconfig/data/UserConfigApiService.kt
+++ b/app/src/main/java/com/sakura_ai_reviewer/feature/userconfig/data/UserConfigApiService.kt
@@ -1,0 +1,58 @@
+package com.sakura_ai_reviewer.feature.userconfig.data
+
+import com.sakura_ai_reviewer.core.network.ApiResponse
+import com.sakura_ai_reviewer.core.network.EmptyData
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+
+interface UserConfigApiService {
+
+    @GET("user-config")
+    suspend fun getUserConfig(): ApiResponse<UserConfigData>
+
+    @PATCH("user-config")
+    suspend fun updateUserConfig(
+        @Body body: UpdateUserConfigRequest
+    ): ApiResponse<EmptyData>
+
+    @GET("user-config/metadata")
+    suspend fun getUserConfigMetadata(): ApiResponse<UserConfigMetadataData>
+}
+
+@JsonClass(generateAdapter = true)
+data class UserConfigData(
+    @Json(name = "configs") val configs: List<UserConfigItem>
+)
+
+@JsonClass(generateAdapter = true)
+data class UserConfigItem(
+    @Json(name = "key") val key: String,
+    @Json(name = "label") val label: String,
+    @Json(name = "description") val description: String,
+    @Json(name = "input_type") val inputType: String,
+    @Json(name = "options") val options: List<UserConfigOption>? = null,
+    @Json(name = "user_value") val userValue: String? = null,
+    @Json(name = "global_value") val globalValue: String,
+    @Json(name = "effective_value") val effectiveValue: String,
+    @Json(name = "is_overridden") val isOverridden: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class UserConfigOption(
+    @Json(name = "value") val value: String,
+    @Json(name = "label") val label: String
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdateUserConfigRequest(
+    @Json(name = "configs") val configs: Map<String, String?>
+)
+
+@JsonClass(generateAdapter = true)
+data class UserConfigMetadataData(
+    @Json(name = "allowed_keys") val allowedKeys: List<String>,
+    @Json(name = "options") val options: Map<String, List<UserConfigOption>>
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Sakura AI Reviewer</string>
+    <string name="asset_statements" translatable="false">[{\"include\": \"https://pr-bot.firefly520.top/.well-known/assetlinks.json\"}]</string>
 
     <!-- Navigation -->
     <string name="nav_dashboard">Dashboard</string>

--- a/docs/api-v1-reference.md
+++ b/docs/api-v1-reference.md
@@ -9,7 +9,7 @@
 ### Base URL
 
 ```
-https://your-server.com/api/v1
+https://pr-bot.firefly520.top/api/v1
 ```
 
 ### 认证方式
@@ -85,6 +85,8 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | 400 | 请求参数错误 |
 | 401 | 未提供认证凭证 / 凭证无效或已过期 |
 | 403 | 权限不足（角色不满足要求） |
+| 428 | 需要先完成 MFA 注册（全局或单用户强制 MFA） |
+| 429 | 请求过于频繁或 MFA 连续失败后被临时锁定 |
 | 404 | 资源不存在 |
 | 409 | 资源冲突（如正在索引中） |
 | 500 | 服务器内部错误 |
@@ -99,8 +101,13 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | OAuth 授权 `GET /auth/github` | 10 次/分钟 |
 | 移动端 OAuth `GET /auth/github/mobile` | 10 次/分钟 |
 | OAuth 回调 `POST /auth/callback` | 5 次/分钟 |
+| 二次验证 `POST /auth/2fa/verify` | 5 次/分钟 |
+| Passkey 二次验证 `POST /auth/2fa/passkey/options` | 默认 10 次/分钟，可通过 `passkeys_authentication_rate_limit` 配置 |
+| Passkey 二次验证 `POST /auth/2fa/passkey/verify` | 默认 10 次/分钟，可通过 `passkeys_authentication_rate_limit` 配置 |
 | 登出 `POST /auth/logout` | 10 次/分钟 |
 | Setup 连接测试 `POST /setup/test-connection` | 10 次/分钟 |
+| Setup 模型列表 `POST /setup/ai-providers/{provider}/models` | 10 次/分钟 |
+| 配置模型列表 `POST /config/ai-providers/{provider}/models` | 10 次/分钟 |
 | Setup 完成 `POST /setup/complete` | 3 次/分钟 |
 | 扫描触发 `POST /scans/trigger` | 3 次/分钟 |
 | 其他端点 | 无额外限流（按服务器默认策略） |
@@ -115,68 +122,88 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | 2 | GET | `/auth/github` | 免认证 | 获取 GitHub OAuth 授权 URL |
 | 3 | GET | `/auth/github/mobile` | 免认证 | 获取移动端 GitHub OAuth 授权 URL |
 | 4 | POST | `/auth/callback` | 免认证 | OAuth 回调换取 Token |
-| 5 | POST | `/auth/logout` | auth | 登出 |
-| 6 | GET | `/auth/me` | auth | 获取当前用户信息 |
-| 7 | GET | `/setup/state` | 免认证 | 获取 Setup 状态 |
-| 8 | POST | `/setup/test-connection` | 免认证 | 测试连接配置 |
-| 9 | POST | `/setup/save-step` | 免认证 | 保存单步配置 |
-| 10 | POST | `/setup/complete` | 免认证 | 完成 Setup 全流程 |
-| 11 | GET | `/dashboard/stats` | auth | 仪表盘统计 |
-| 12 | GET | `/dashboard/recent-reviews` | auth | 最近审查列表 |
-| 13 | GET | `/dashboard/chart-data` | auth | 仪表盘图表数据 |
-| 14 | POST | `/dashboard/cache/refresh` | auth | 刷新仪表盘缓存 |
-| 15 | GET | `/reviews` | auth | PR 审查列表（分页） |
-| 16 | GET | `/reviews/export` | auth | 导出审查 CSV |
-| 17 | GET | `/reviews/{review_id}` | auth | 审查详情（含评论） |
-| 18 | GET | `/reviews/{review_id}/files` | auth | 审查文件级统计 |
-| 19 | GET | `/reviews/{review_id}/comments` | auth | 审查评论列表 |
-| 20 | GET | `/reviews/{review_id}/files/{file_path}` | auth | 特定文件评论 |
-| 21 | GET | `/issues` | auth | Issue 分析列表（分页） |
-| 22 | GET | `/issues/stats` | auth | Issue 统计 |
-| 23 | GET | `/issues/{issue_id}` | auth | Issue 分析详情 |
-| 24 | POST | `/issues/{issue_id}/reanalyze` | auth | 重新分析 Issue |
-| 25 | GET | `/users` | admin | 用户列表（分页） |
-| 26 | POST | `/users` | super_admin | 创建用户 |
-| 27 | GET | `/users/{user_id}` | admin | 用户详情 |
-| 28 | PATCH | `/users/{user_id}/role` | admin | 修改用户角色 |
-| 29 | PATCH | `/users/{user_id}/quota` | admin | 修改用户 PR 配额 |
-| 30 | PATCH | `/users/{user_id}/issue-quota` | admin | 修改用户 Issue 配额 |
-| 31 | POST | `/users/{user_id}/toggle` | admin | 启用/禁用用户 |
-| 32 | DELETE | `/users/{user_id}` | super_admin | 删除用户 |
-| 33 | PATCH | `/users/{user_id}/info` | super_admin | 修改用户基本信息 |
-| 34 | POST | `/users/{user_id}/reset-quota` | super_admin | 重置用户配额使用量 |
-| 35 | GET | `/repos` | admin | 仓库列表 |
-| 36 | POST | `/repos/{repo_name}/index-docs` | admin | 触发文档索引 |
-| 37 | POST | `/repos/{repo_name}/index-code` | admin | 触发代码索引 |
-| 38 | POST | `/repos/{repo_name}/index-issues` | admin | 触发 Issues 索引 |
-| 39 | POST | `/repos/{repo_name}/scan` | super_admin | 触发仓库扫描 |
-| 40 | GET | `/config/general` | super_admin | 获取全局配置 |
-| 41 | PATCH | `/config/general` | super_admin | 更新全局配置 |
-| 42 | GET | `/config/strategies` | super_admin | 获取策略配置 |
-| 43 | PATCH | `/config/strategies/{section}` | super_admin | 更新策略配置 section |
-| 44 | GET | `/config/labels` | super_admin | 获取标签配置 |
-| 45 | PUT | `/config/labels` | super_admin | 更新标签定义 |
-| 46 | PATCH | `/config/labels/recommendation` | super_admin | 更新标签推荐设置 |
-| 47 | GET | `/logs/reviews` | auth | 审查日志列表（分页） |
-| 48 | GET | `/logs/reviews/{review_id}` | auth | 审查日志详情 |
-| 49 | GET | `/logs/actions` | admin | 操作日志列表（分页） |
-| 50 | GET | `/logs/actions/{log_id}` | admin | 操作日志详情 |
-| 51 | GET | `/queue/stats` | admin | 队列统计 |
-| 52 | GET | `/queue/items` | admin | 队列列表（分页） |
-| 53 | GET | `/queue/items/{item_id}` | admin | 队列项详情 |
-| 54 | POST | `/queue/items/{item_id}/retry` | admin | 重试队列项 |
-| 55 | DELETE | `/queue/items/{item_id}` | admin | 删除队列项 |
-| 56 | POST | `/queue/purge` | admin | 批量清理队列 |
-| 57 | GET | `/scans` | auth | 扫描列表（分页） |
-| 58 | GET | `/scans/stats` | auth | 扫描统计 |
-| 59 | GET | `/scans/{scan_id}` | auth | 扫描详情 |
-| 60 | POST | `/scans/trigger` | super_admin | 手动触发扫描 |
-| 61 | POST | `/scans/{scan_id}/retry` | super_admin | 重试扫描 |
-| 62 | POST | `/scans/{scan_id}/cancel` | super_admin | 取消扫描 |
-| 63 | GET | `/settings` | auth | 获取个人设置 |
-| 64 | PATCH | `/settings` | auth | 更新个人设置 |
-| 65 | GET | `/settings/about` | auth | 获取系统版本信息 |
-| 66 | GET | `/events` | auth | SSE 事件流 |
+| 5 | POST | `/auth/2fa/verify` | 免认证 | 二次验证并换取正式 Token |
+| 6 | POST | `/auth/logout` | auth | 登出 |
+| 7 | GET | `/auth/me` | auth | 获取当前用户信息 |
+| 8 | GET | `/setup/state` | 免认证 | 获取 Setup 状态 |
+| 9 | POST | `/setup/test-connection` | 免认证 | 测试连接配置 |
+| 10 | GET | `/setup/ai-providers` | 免认证 | 获取 Setup 可用 AI 厂商 |
+| 11 | POST | `/setup/ai-providers/{provider}/models` | 免认证 | Setup 阶段获取模型列表 |
+| 12 | POST | `/setup/save-step` | 免认证 | 保存单步配置 |
+| 13 | POST | `/setup/complete` | 免认证 | 完成 Setup 全流程 |
+| 14 | GET | `/dashboard/stats` | auth | 仪表盘统计 |
+| 15 | GET | `/dashboard/recent-reviews` | auth | 最近审查列表 |
+| 16 | GET | `/dashboard/chart-data` | auth | 仪表盘图表数据 |
+| 17 | POST | `/dashboard/cache/refresh` | auth | 刷新仪表盘缓存 |
+| 18 | GET | `/reviews` | auth | PR 审查列表（分页） |
+| 19 | GET | `/reviews/export` | auth | 导出审查 CSV |
+| 20 | GET | `/reviews/{review_id}` | auth | 审查详情（含评论） |
+| 21 | GET | `/reviews/{review_id}/files` | auth | 审查文件级统计 |
+| 22 | GET | `/reviews/{review_id}/comments` | auth | 审查评论列表 |
+| 23 | GET | `/reviews/{review_id}/files/{file_path}` | auth | 特定文件评论 |
+| 24 | GET | `/issues` | auth | Issue 分析列表（分页） |
+| 25 | GET | `/issues/stats` | auth | Issue 统计 |
+| 26 | GET | `/issues/{issue_id}` | auth | Issue 分析详情 |
+| 27 | POST | `/issues/{issue_id}/reanalyze` | auth | 重新分析 Issue |
+| 28 | GET | `/users` | admin | 用户列表（分页） |
+| 29 | POST | `/users` | super_admin | 创建用户 |
+| 30 | GET | `/users/{user_id}` | admin | 用户详情 |
+| 31 | PATCH | `/users/{user_id}/role` | admin | 修改用户角色 |
+| 32 | PATCH | `/users/{user_id}/quota` | admin | 修改用户 PR 配额 |
+| 33 | PATCH | `/users/{user_id}/issue-quota` | admin | 修改用户 Issue 配额 |
+| 34 | POST | `/users/{user_id}/toggle` | admin | 启用/禁用用户 |
+| 35 | DELETE | `/users/{user_id}` | super_admin | 删除用户 |
+| 36 | PATCH | `/users/{user_id}/info` | super_admin | 修改用户基本信息 |
+| 37 | POST | `/users/{user_id}/reset-quota` | super_admin | 重置用户配额使用量 |
+| 38 | GET | `/repos` | admin | 仓库列表 |
+| 39 | POST | `/repos/{repo_name}/index-docs` | admin | 触发文档索引 |
+| 40 | POST | `/repos/{repo_name}/index-code` | admin | 触发代码索引 |
+| 41 | POST | `/repos/{repo_name}/index-issues` | admin | 触发 Issues 索引 |
+| 42 | POST | `/repos/{repo_name}/scan` | super_admin | 触发仓库扫描 |
+| 43 | GET | `/config/ai-providers` | super_admin | 获取内置 AI 厂商列表 |
+| 44 | POST | `/config/ai-providers/{provider}/models` | super_admin | 按厂商获取模型列表 |
+| 45 | GET | `/config/general` | super_admin | 获取全局配置 |
+| 46 | PATCH | `/config/general` | super_admin | 更新全局配置 |
+| 47 | GET | `/config/strategies` | super_admin | 获取策略配置 |
+| 48 | PATCH | `/config/strategies/{section}` | super_admin | 更新策略配置 section |
+| 49 | GET | `/config/labels` | super_admin | 获取标签配置 |
+| 50 | PUT | `/config/labels` | super_admin | 更新标签定义 |
+| 51 | PATCH | `/config/labels/recommendation` | super_admin | 更新标签推荐设置 |
+| 52 | GET | `/logs/reviews` | auth | 审查日志列表（分页） |
+| 53 | GET | `/logs/reviews/{review_id}` | auth | 审查日志详情 |
+| 54 | GET | `/logs/actions` | admin | 操作日志列表（分页） |
+| 55 | GET | `/logs/actions/{log_id}` | admin | 操作日志详情 |
+| 56 | GET | `/queue/stats` | admin | 队列统计 |
+| 57 | GET | `/queue/items` | admin | 队列列表（分页） |
+| 58 | GET | `/queue/items/{item_id}` | admin | 队列项详情 |
+| 59 | POST | `/queue/items/{item_id}/retry` | admin | 重试队列项 |
+| 60 | DELETE | `/queue/items/{item_id}` | admin | 删除队列项 |
+| 61 | POST | `/queue/purge` | admin | 批量清理队列 |
+| 62 | GET | `/scans` | admin | 扫描列表（分页） |
+| 63 | GET | `/scans/stats` | admin | 扫描统计 |
+| 64 | GET | `/scans/{scan_id}` | admin | 扫描详情 |
+| 65 | POST | `/scans/trigger` | super_admin | 手动触发扫描 |
+| 66 | POST | `/scans/{scan_id}/retry` | super_admin | 重试扫描 |
+| 67 | POST | `/scans/{scan_id}/cancel` | super_admin | 取消扫描 |
+| 68 | GET | `/settings` | auth | 获取个人设置 |
+| 69 | PATCH | `/settings` | auth | 更新个人设置 |
+| 70 | GET | `/settings/about` | auth | 获取系统版本信息 |
+| 71 | GET | `/user-config` | auth | 获取当前用户可覆盖配置 |
+| 72 | PATCH | `/user-config` | auth | 更新当前用户配置覆盖 |
+| 73 | GET | `/user-config/metadata` | auth | 获取用户配置元数据 |
+| 74 | GET | `/billing/plans` | auth | 获取可用套餐 |
+| 75 | POST | `/billing/redeem` | auth | 兑换配额码 |
+| 76 | GET | `/billing/orders` | auth | 获取订单历史 |
+| 77 | POST | `/billing/admin/plans` | super_admin | 创建套餐 |
+| 78 | PUT | `/billing/admin/plans/{plan_id}` | super_admin | 编辑套餐 |
+| 79 | DELETE | `/billing/admin/plans/{plan_id}` | super_admin | 删除套餐（默认软删除，可选硬删除） |
+| 80 | POST | `/billing/admin/codes/generate` | super_admin | 批量生成兑换码 |
+| 81 | PUT | `/billing/admin/codes/{code_id}` | super_admin | 编辑兑换码 |
+| 82 | DELETE | `/billing/admin/codes/{code_id}` | super_admin | 删除兑换码 |
+| 83 | POST | `/billing/admin/grant` | super_admin | 手动为用户充值 |
+| 84 | POST | `/auth/2fa/passkey/options` | 免认证 | 创建 API Passkey 认证 options |
+| 85 | POST | `/auth/2fa/passkey/verify` | 免认证 | 验证 API Passkey 认证 |
+| 86 | GET | `/events` | auth | SSE 事件流 |
 
 ---
 
@@ -324,7 +351,155 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 }
 ```
 
+当用户已启用 TOTP 或 Passkey，OAuth 回调不会直接签发正式 `access_token`，而是返回 `message="mfa_required"` 与临时 `mfa_token`：
+
+```json
+{
+  "success": true,
+  "message": "mfa_required",
+  "data": {
+    "mfa_required": true,
+    "mfa_token": "eyJhbGciOiJIUzI1NiIs...",
+    "methods": ["totp", "recovery_code"],
+    "user": {
+      "sub": "octocat",
+      "role": "user",
+      "user_id": 1,
+      "github_id": 12345,
+      "avatar_url": "https://avatars.githubusercontent.com/u/12345?v=4"
+    }
+  }
+}
+```
+
+客户端收到该响应后，应根据 `methods` 字段选择验证方式：TOTP/恢复码调用 `POST /auth/2fa/verify`，Passkey 调用 `POST /auth/2fa/passkey/options` 后再提交 `POST /auth/2fa/passkey/verify` 换取正式 Token。
+
 > **Android 接入建议**：获取 `access_token` 后存储到本地安全存储（如 EncryptedSharedPreferences），后续所有请求通过 `Authorization: Bearer <access_token>` 携带。
+
+---
+
+#### POST /auth/2fa/verify
+
+验证 OAuth 登录后返回的临时 `mfa_token` 和 TOTP/恢复码，成功后签发正式 JWT access_token。
+
+**认证级别**：免认证
+
+**限流**：5 次/分钟
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `mfa_token` | string | 是 | OAuth 回调返回的临时二次验证 Token |
+| `code` | string | 是 | 6 位 TOTP 验证码或恢复码 |
+
+**请求示例**：
+
+```json
+{
+  "mfa_token": "eyJhbGciOiJIUzI1NiIs...",
+  "code": "123456"
+}
+```
+
+**响应字段**：同 `POST /auth/callback` 成功签发 Token 时的响应。
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "access_token": "eyJhbGciOiJIUzI1NiIs...",
+    "token_type": "bearer",
+    "expires_in": 86400,
+    "user": {
+      "sub": "octocat",
+      "role": "user",
+      "user_id": 1,
+      "github_id": 12345,
+      "avatar_url": "https://avatars.githubusercontent.com/u/12345?v=4"
+    }
+  }
+}
+```
+
+**常见错误**：
+
+| HTTP 状态码 | 说明 |
+|-------------|------|
+| 400 | 用户未启用二次验证、验证码/恢复码无效，或当前用户需使用 Passkey 完成验证 |
+| 401 | `mfa_token` 无效或已过期 |
+| 429 | 账户因连续 MFA 验证失败被临时锁定 |
+
+#### POST /auth/2fa/passkey/options
+
+创建 API Passkey（WebAuthn）认证选项，用于移动端 Passkey 二次验证。与 TOTP/恢复码验证流程并列，客户端可根据 `mfa_required` 响应中的 `methods` 字段选择验证方式。
+
+**认证级别**：免认证
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `mfa_token` | string | 是 | OAuth 回调返回的临时二次验证 Token |
+
+**响应字段**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `data.challenge_id` | string | 服务端保存的 challenge ID，提交验证时需原样带回 |
+| `data.public_key` | object | WebAuthn Authentication Options（PublicKeyCredentialRequestOptions JSON） |
+| `data.rp_id` | string | Relying Party ID |
+| `data.origin` | string | 服务端用于校验的 Origin |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "challenge_id": "base64url-challenge-id",
+    "public_key": {
+      "challenge": "base64url-challenge",
+      "rpId": "example.com",
+      "allowCredentials": [],
+      "timeout": 300000,
+      "userVerification": "required"
+    },
+    "rp_id": "example.com",
+    "origin": "https://example.com"
+  }
+}
+```
+
+---
+
+#### POST /auth/2fa/passkey/verify
+
+验证 API Passkey（WebAuthn）认证结果，成功后签发正式 JWT access_token。
+
+**认证级别**：免认证
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `mfa_token` | string | 是 | OAuth 回调返回的临时二次验证 Token |
+| `challenge_id` | string | 是 | `POST /auth/2fa/passkey/options` 返回的 challenge ID |
+| `credential` | object | 是 | WebAuthn 认证结果（navigator.credentials.get() 返回值 JSON 序列化）|
+
+**响应字段**：同 `POST /auth/callback` 成功签发 Token 时的响应。
+
+**常见错误**：
+
+| HTTP 状态码 | 说明 |
+|-------------|------|
+| 400 | Passkey 认证失败或凭证无效 |
+| 401 | `mfa_token` 无效或已过期 |
+| 429 | 账户因连续 MFA 验证失败被临时锁定 |
 
 ---
 
@@ -448,8 +623,10 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | `redis_url` | string | 条件 | Redis 连接 URL（type=redis） |
 | `app_id` | string | 条件 | GitHub App ID（type=github） |
 | `private_key` | string | 条件 | GitHub 私钥（type=github） |
-| `api_key` | string | 条件 | OpenAI API Key（type=openai） |
-| `api_base` | string | 条件 | OpenAI API Base URL（type=openai） |
+| `provider` | string | 否 | AI 厂商 ID（type=openai，默认 `custom`） |
+| `api_key` | string | 条件 | OpenAI 兼容 API Key（type=openai） |
+| `api_base` | string | 条件 | OpenAI 兼容 API Base URL（type=openai） |
+| `model` | string | 否 | 用于辅助查询上下文窗口的模型名（type=openai） |
 | `bot_token` | string | 条件 | Telegram Bot Token（type=telegram） |
 
 **请求示例**：
@@ -470,6 +647,83 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
   "data": {
     "success": true,
     "message": "数据库连接成功"
+  }
+}
+```
+
+---
+
+#### GET /setup/ai-providers
+
+获取 Setup Wizard 可选择的内置 AI 厂商列表。
+
+**认证级别**：免认证（需 bootstrap 模式）
+
+**响应字段**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `data.providers` | array | AI Provider 元数据列表，包含 `id`、`label`、`base_url`、`default_model`、是否支持模型列表和上下文窗口等信息 |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "providers": [
+      {
+        "id": "deepseek",
+        "label": "DeepSeek",
+        "base_url": "https://api.deepseek.com/v1",
+        "default_model": "deepseek-chat",
+        "models_endpoint": "models",
+        "model_detail_endpoint": "models/{model}",
+        "supports_model_list": true,
+        "supports_context_window": true,
+        "notes": ""
+      }
+    ]
+  }
+}
+```
+
+---
+
+#### POST /setup/ai-providers/{provider}/models
+
+Setup 阶段按 AI 厂商获取模型列表，并尽可能提取上下文窗口信息。
+
+**认证级别**：免认证（需 bootstrap 模式）
+
+**限流**：10 次/分钟
+
+**路径参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `provider` | string | AI 厂商 ID，如 `openai`、`deepseek`、`qwen`、`custom` |
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `api_key` | string | 否 | API Key |
+| `api_base` | string | 否 | 自定义 API Base URL |
+| `model` | string | 否 | 指定模型名，用于查询模型详情时辅助提取上下文窗口 |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "success": true,
+    "models": ["deepseek-chat", "deepseek-reasoner"],
+    "context_window_k": 64,
+    "message": "获取模型列表成功"
   }
 }
 ```
@@ -530,9 +784,11 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | `GITHUB_APP_ID` | string | GitHub App ID |
 | `GITHUB_PRIVATE_KEY` | string | GitHub App 私钥 |
 | `GITHUB_WEBHOOK_SECRET` | string | GitHub Webhook 密钥 |
-| `OPENAI_API_KEY` | string | OpenAI API Key |
-| `OPENAI_API_BASE` | string | OpenAI API Base URL |
-| `OPENAI_MODEL` | string | OpenAI 模型名 |
+| `AI_PROVIDER` | string | AI 厂商 ID |
+| `OPENAI_API_KEY` | string | OpenAI 兼容 API Key |
+| `OPENAI_API_BASE` | string | OpenAI 兼容 API Base URL |
+| `OPENAI_MODEL` | string | OpenAI 兼容模型名 |
+| `SUMMARY_PROVIDER` | string | Summary 使用的 AI 厂商 ID |
 | `TELEGRAM_BOT_TOKEN` | string | Telegram Bot Token |
 | `APP_DOMAIN` | string | 应用域名 |
 | `APP_PORT` | string | 应用端口 |
@@ -551,6 +807,8 @@ JWT Token 通过 OAuth 登录流程获取，有效期 24 小时（86400 秒）�
 | `RERANK_BASE_URL` | string | Rerank Base URL |
 | `RERANK_MODEL` | string | Rerank 模型名 |
 | `RERANK_PROVIDER` | string | Rerank 提供商 |
+
+> **说明**：当前 Setup 状态步骤按 `database`、`github`、`ai`、`rag`、`admin` 分组展示，服务端实际必填检查来自 `field_groups` 返回值。
 
 **响应示例**：
 
@@ -1546,6 +1804,54 @@ Issue 分析详情。
 
 > 所有配置端点需要 super_admin 权限。敏感字段（含 `secret`、`key`、`token`、`password`、`credential`）会被脱敏为 `****` 格式。错误响应不暴露内部异常详情，仅返回通用错误消息。
 
+#### GET /config/ai-providers
+
+获取内置 AI 厂商列表，用于 WebUI 配置页或客户端生成下拉选项。
+
+**认证级别**：super_admin
+
+**响应字段**：同 `GET /setup/ai-providers`。
+
+---
+
+#### POST /config/ai-providers/{provider}/models
+
+按厂商获取模型列表。若请求体未提供 `api_key` 或 `api_base`，服务端会尝试回退使用数据库中保存的 `openai_api_key` / `openai_api_base`。
+
+**认证级别**：super_admin
+
+**限流**：10 次/分钟
+
+**路径参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `provider` | string | AI 厂商 ID，如 `openai`、`deepseek`、`qwen`、`custom` |
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `api_key` | string | 否 | API Key；为空时尝试读取已保存配置 |
+| `api_base` | string | 否 | API Base URL；为空时使用 provider 默认地址或已保存配置 |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "success": true,
+    "models": ["gpt-4o-mini", "gpt-4o"],
+    "context_window_k": 128,
+    "message": "获取模型列表成功"
+  }
+}
+```
+
+---
+
 #### GET /config/general
 
 获取全局配置。
@@ -1556,7 +1862,18 @@ Issue 分析详情。
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `data.configs` | object | 键值对（键为配置名，值为配置值，敏感值已脱敏） |
+| `data.configs` | object | 键值对（键为配置名，值为配置值，敏感值已脱敏；包括数据库中保存的动态配置） |
+
+常见可配置键包括：
+
+| 配置键 | 说明 |
+|--------|------|
+| `openai_api_key` / `openai_api_base` / `openai_model` | OpenAI 兼容主模型配置 |
+| `output_language` | AI 输出语言配置 |
+| `init_user_daily_quota` / `init_user_weekly_quota` / `init_user_monthly_quota` | 自注册用户基础 PR 配额 |
+| `init_user_issue_daily_quota` / `init_user_issue_weekly_quota` / `init_user_issue_monthly_quota` | 自注册用户基础 Issue 配额 |
+| `init_admin_agent_daily_quota` / `init_admin_agent_weekly_quota` / `init_admin_agent_monthly_quota` | Setup 初始管理员 Agent 配额 |
+| `init_user_agent_daily_quota` / `init_user_agent_weekly_quota` / `init_user_agent_monthly_quota` | 自注册用户基础 Agent 配额 |
 
 **响应示例**：
 
@@ -2034,7 +2351,7 @@ Issue 分析详情。
 
 扫描列表，支持分页和过滤。
 
-**认证级别**：auth
+**认证级别**：admin
 
 **查询参数**：
 
@@ -2067,7 +2384,7 @@ Issue 分析详情。
 
 扫描统计数据。
 
-**认证级别**：auth
+**认证级别**：admin
 
 **响应字段**：
 
@@ -2101,7 +2418,7 @@ Issue 分析详情。
 
 扫描详情，含所有发现（findings）。
 
-**认证级别**：auth
+**认证级别**：admin
 
 **路径参数**：
 
@@ -2322,15 +2639,428 @@ Issue 分析详情。
   "success": true,
   "message": "ok",
   "data": {
-    "version": "2.8.2",
-    "build_date": "2026-04-17"
+    "version": "2.11.0",
+    "build_date": "2026-05-11"
   }
 }
 ```
 
 ---
 
-### 3.14 SSE 事件流 (Events)
+### 3.14 用户级配置 (User Config)
+
+用户级配置用于让普通用户覆盖被系统允许的偏好配置。当前仅开放 `output_language`，用于控制该用户触发的 AI 输出语言。配置解析顺序为：**UserConfig → AppConfig → Settings 默认值**。
+
+#### GET /user-config
+
+获取当前用户可覆盖的配置项及其有效值。
+
+**认证级别**：auth
+
+**响应字段**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `data.configs` | array | 配置项状态列表 |
+| `data.configs[].key` | string | 配置键 |
+| `data.configs[].label` | string | 展示名称 |
+| `data.configs[].description` | string | 配置说明 |
+| `data.configs[].input_type` | string | 输入类型，如 `select` |
+| `data.configs[].options` | array | 可选项列表 |
+| `data.configs[].user_value` | string \| null | 用户覆盖值；为 `null` 表示未覆盖 |
+| `data.configs[].global_value` | string | 全局配置值 |
+| `data.configs[].effective_value` | string | 当前实际生效值 |
+| `data.configs[].is_overridden` | bool | 是否存在用户覆盖 |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "configs": [
+      {
+        "key": "output_language",
+        "label": "输出语言",
+        "description": "AI 评论和报告使用的语言",
+        "input_type": "select",
+        "options": [
+          {"value": "", "label": "跟随全局"},
+          {"value": "zh-CN", "label": "简体中文"},
+          {"value": "en", "label": "English"}
+        ],
+        "user_value": "en",
+        "global_value": "zh-CN",
+        "effective_value": "en",
+        "is_overridden": true
+      }
+    ]
+  }
+}
+```
+
+---
+
+#### PATCH /user-config
+
+更新当前用户的配置覆盖。传入 `null` 表示删除该用户覆盖值并回退到全局配置。
+
+**认证级别**：auth
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `configs` | object | 是 | 键值对，当前仅允许 `output_language` |
+
+**请求示例（设置英文输出）**：
+
+```json
+{
+  "configs": {
+    "output_language": "en"
+  }
+}
+```
+
+**请求示例（删除覆盖，回退全局）**：
+
+```json
+{
+  "configs": {
+    "output_language": null
+  }
+}
+```
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "配置已更新"
+}
+```
+
+**校验规则**：
+
+| 配置键 | 允许值 | 说明 |
+|--------|--------|------|
+| `output_language` | `""` / `"zh-CN"` / `"en"` / `null` | 空字符串或 `null` 表示跟随全局配置 |
+
+---
+
+#### GET /user-config/metadata
+
+获取用户可配置项元数据，适合客户端构建表单。
+
+**认证级别**：auth
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "allowed_keys": ["output_language"],
+    "options": {
+      "output_language": [
+        {"value": "", "label": "跟随全局"},
+        {"value": "zh-CN", "label": "简体中文"},
+        {"value": "en", "label": "English"}
+      ]
+    }
+  }
+}
+```
+
+---
+
+### 3.15 付费配额 (Billing)
+
+Billing 端点仅在付费配额系统启用时可用；未启用时会返回拒绝访问或功能未启用错误。当前 Billing 模块部分响应为直接 JSON，不完全使用统一 `success_response` 包装。
+
+#### GET /billing/plans
+
+列出当前可用套餐。
+
+**认证级别**：auth
+
+**响应示例**：
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Pro 月度包",
+    "plan_type": "subscription",
+    "price_cents": 990,
+    "currency": "CNY",
+    "duration_days": 30,
+    "pr_quota_bonus": 0,
+    "pr_daily_add": 10,
+    "pr_weekly_add": 0,
+    "pr_monthly_add": 0,
+    "issue_quota_bonus": 0,
+    "issue_daily_add": 20,
+    "issue_weekly_add": 0,
+    "issue_monthly_add": 0,
+    "description": "月度订阅套餐"
+  }
+]
+```
+
+---
+
+#### POST /billing/redeem
+
+兑换配额兑换码。
+
+**认证级别**：auth
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `code` | string | 是 | 兑换码 |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "order_no": "ORD202605090001",
+  "plan_name": "Pro 月度包"
+}
+```
+
+---
+
+#### GET /billing/orders
+
+获取当前用户订单历史。
+
+**认证级别**：auth
+
+**查询参数**：
+
+| 参数 | 类型 | 默认值 | 范围 | 说明 |
+|------|------|--------|------|------|
+| `limit` | int | 20 | 1-100 | 返回数量 |
+| `offset` | int | 0 | >= 0 | 偏移量 |
+
+**响应示例**：
+
+```json
+{
+  "total": 1,
+  "orders": [
+    {
+      "id": 1,
+      "order_no": "ORD202605090001",
+      "plan_name": "Pro 月度包",
+      "amount_cents": 990,
+      "currency": "CNY",
+      "status": "paid",
+      "payment_provider": "redeem_code",
+      "created_at": "2026-05-09T12:00:00",
+      "fulfilled_at": "2026-05-09T12:00:01"
+    }
+  ]
+}
+```
+
+---
+
+#### POST /billing/admin/plans
+
+创建套餐。
+
+**认证级别**：super_admin
+
+**请求体字段**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 套餐名称 |
+| `plan_type` | string | 是 | `one_time` 或 `subscription` |
+| `price_cents` | int | 否 | 价格（分） |
+| `currency` | string | 否 | 货币，默认 `CNY` |
+| `duration_days` | int \| null | 否 | 有效天数 |
+| `pr_quota_bonus` / `issue_quota_bonus` | int | 否 | 一次性配额增量 |
+| `pr_daily_add` / `issue_daily_add` | int | 否 | 每日配额增量 |
+| `pr_weekly_add` / `issue_weekly_add` | int | 否 | 每周配额增量 |
+| `pr_monthly_add` / `issue_monthly_add` | int | 否 | 每月配额增量 |
+| `description` | string \| null | 否 | 套餐描述 |
+| `sort_order` | int | 否 | 排序值 |
+
+**响应示例**：
+
+```json
+{
+  "id": 1,
+  "name": "Pro 月度包"
+}
+```
+
+---
+
+#### PUT /billing/admin/plans/{plan_id}
+
+编辑现有套餐。
+
+**认证级别**：super_admin
+
+**路径参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `plan_id` | int | 套餐 ID |
+
+**请求体字段**：同创建套餐（`POST /billing/admin/plans`），所有字段可选，仅传递需要修改的字段。
+
+**响应示例**：
+
+```json
+{
+  "id": 1,
+  "name": "Pro 月度包（更新）"
+}
+```
+
+---
+
+#### DELETE /billing/admin/plans/{plan_id}
+
+删除套餐。默认软删除；传入 `hard=true` 时从数据库硬删除。
+
+**认证级别**：super_admin
+
+**路径参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `plan_id` | int | 套餐 ID |
+
+**查询参数**：
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `hard` | bool | `false` | 是否硬删除 |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "id": 1,
+  "name": "Pro 月度包",
+  "hard_delete": false
+}
+```
+
+---
+
+#### PUT /billing/admin/codes/{code_id}
+
+编辑兑换码（状态、过期时间、最大使用次数）。
+
+**认证级别**：super_admin
+
+**路径参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `code_id` | int | 兑换码 ID |
+
+**请求体字段**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `status` | string | 否 | 兑换码状态：`active` / `disabled` |
+| `expires_at` | string \| null | 否 | 过期时间 |
+| `max_uses` | int | 否 | 最大使用次数 |
+| `plan_id` | int | 否 | 绑定的新套餐 ID |
+
+---
+
+#### DELETE /billing/admin/codes/{code_id}
+
+删除兑换码。
+
+**认证级别**：super_admin
+
+**路径参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `code_id` | int | 兑换码 ID |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "id": 1,
+  "code": "SAKURA-ABCD"
+}
+```
+
+---
+
+#### POST /billing/admin/codes/generate
+
+批量生成兑换码。
+
+**认证级别**：super_admin
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `plan_id` | int | 是 | 套餐 ID |
+| `count` | int | 是 | 生成数量，1-100 |
+| `batch_name` | string \| null | 否 | 批次名称 |
+| `max_uses` | int | 否 | 每个兑换码最大使用次数，默认 1 |
+
+**响应示例**：
+
+```json
+{
+  "count": 2,
+  "codes": ["SAKURA-ABCD", "SAKURA-EFGH"]
+}
+```
+
+---
+
+#### POST /billing/admin/grant
+
+管理员手动为用户发放套餐权益。
+
+**认证级别**：super_admin
+
+**请求体**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `user_id` | int | 是 | 目标用户 ID |
+| `plan_id` | int | 是 | 套餐 ID |
+
+**响应示例**：
+
+```json
+{
+  "success": true,
+  "order_no": "ORD202605090002"
+}
+```
+
+---
+
+### 3.16 SSE 事件流 (Events)
 
 #### GET /events
 
@@ -2386,9 +3116,19 @@ data: {"scan_id": 101, "progress": 50, ...}
 
 4. POST /api/v1/auth/callback
    Body: {"code": "xxx", "state": "xxx"}
-   -> 获取 access_token
+  -> 获取 access_token，或在用户启用 MFA 时获取 mfa_token
 
-5. 后续请求: Authorization: Bearer <access_token>
+5. 如返回 message="mfa_required":
+   - TOTP/恢复码：POST /api/v1/auth/2fa/verify
+     Body: {"mfa_token": "xxx", "code": "123456"}
+   - Passkey：POST /api/v1/auth/2fa/passkey/options
+     Body: {"mfa_token": "xxx"}
+     -> 使用 public_key 发起 WebAuthn 认证
+     POST /api/v1/auth/2fa/passkey/verify
+     Body: {"mfa_token": "xxx", "challenge_id": "xxx", "credential": {...}}
+   -> 获取正式 access_token
+
+6. 后续请求: Authorization: Bearer <access_token>
 ```
 
 ### 常用请求模板
@@ -2417,4 +3157,4 @@ val sseSource = EventSource.Factory.create(request, eventListener)
 
 ---
 
-> 文档版本：v1.1 | 最后更新：2026-04-18 | 端点总数：66
+> 文档版本：v1.3 | 最后更新：2026-05-21 | 端点总数：86

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ browser = "1.9.0"
 
 # Security
 securityCrypto = "1.1.0-alpha06"
+credentials = "1.7.0-alpha02"
 
 # Coroutines
 coroutines = "1.10.2"
@@ -97,6 +98,8 @@ browser = { group = "androidx.browser", name = "browser", version.ref = "browser
 
 # Security
 security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
+credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
 
 # Coroutines
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
- add credentials and Play Services auth dependencies
- expose asset statements and view intent filters in the manifest
- expand public network paths for passkey and 2FA routes
- skip auth interception when requests already carry credentials
- wire additional API services into the network module